### PR TITLE
Run Python through CoreOS Toolbox

### DIFF
--- a/inventory/group_vars/corebernetes.yaml
+++ b/inventory/group_vars/corebernetes.yaml
@@ -1,2 +1,1 @@
-ansible_python_interpreter: bin/python
 ansible_ssh_user: core

--- a/inventory/group_vars/corebernetes.yaml
+++ b/inventory/group_vars/corebernetes.yaml
@@ -1,1 +1,2 @@
 ansible_ssh_user: core
+ansible_python_interpreter: /opt/bin/python

--- a/playbooks/install.yaml
+++ b/playbooks/install.yaml
@@ -3,12 +3,7 @@
   vars:
     ct_version: v0.9.0
   tasks:
-  # install a python "binary" to allow ansible's modules to work, it's actually just a docker wrapper
-  - name: setup python interpreter
-    block:
-    - raw: mkdir -p {{ ansible_python_interpreter | dirname | quote }}
-    - raw: printf '#!/bin/sh -e\ndocker run -itu "$UID" -v "$PWD:$PWD" -w "$PWD" --rm python:alpine python "$@"\n' > {{ ansible_python_interpreter | quote }}
-    - raw: chmod +x {{ ansible_python_interpreter | quote }}
+  - include_tasks: tasks/install-python.yaml
 
   - name: install ct
     get_url:

--- a/playbooks/tasks/install-python.yaml
+++ b/playbooks/tasks/install-python.yaml
@@ -1,0 +1,53 @@
+# coreos' toolbox allows us to inject our own tooling via a container filesystem and systemd-nspawn
+# we configure toolbox to run a python container, then configure ansible to use this for its modules
+# https://github.com/coreos/toolbox
+
+- name: create toolboxrc
+  # ansible prepends spaces in front of multiline raw commands, breaking heredocs
+  # one workaround for this is to assign the command to a variable as we've done here
+  # https://github.com/ansible/ansible/issues/12034#issuecomment-453723192
+  raw: "{{ cmd }}"
+  vars:
+    # escaping or quoting the "limit string" in a heredoc disables parameter substitution
+    # http://tldp.org/LDP/abs/html/here-docs.html#EX71C
+    cmd: |
+      cat > ~/.toolboxrc << \EOF
+      TOOLBOX_DOCKER_IMAGE=python
+      TOOLBOX_DOCKER_TAG=3
+      TOOLBOX_BIND="$TOOLBOX_BIND --bind=/etc/passwd:/etc/passwd --bind=/home:/home"
+      TOOLBOX_ENV=--chdir="/media/root/$PWD"
+      TOOLBOX_USER="$USER"
+
+      # if this file was invoked under a name other than "toolbox" we want to use that name as the first argument
+      # this allows toolbox to be used with ansible's ansible_xxx_interpreter variables
+      # https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#ansible-python-interpreter
+      if [ "$(basename $0)" != toolbox ]; then
+          # less recent versions (< v240) of systemd-nspawn use the host's $PATH instead of the container's to invoke
+          # the given command, and since the python docker image ships with several binaries across several versions in
+          # several places we're better off just being specific about which we want
+          # https://github.com/systemd/systemd/issues/10377
+          # https://github.com/docker-library/python/issues/345
+          set -- "/usr/local/bin/$(basename "$0")" "$@"
+      fi
+      EOF
+
+# the first run of toolbox will pull and unpack the docker image to the local filesystem
+# this can take a while so we'll pull it eagerly to avoid confusion or timeouts in subsequent steps
+- name: verify toolbox container image
+  raw: toolbox echo hello world
+
+- name: create /opt/bin
+  become: true
+  raw: mkdir -p /opt/bin
+
+- name: link binaries to toolbox
+  become: true
+  raw: ln -fs /usr/bin/toolbox "/opt/bin/{{ item }}"
+  loop: &binaries
+  - python
+  - pip
+
+- name: set binary paths
+  set_fact:
+    "ansible_{{ item }}_interpreter": "/opt/bin/{{ item }}"
+  loop: *binaries

--- a/playbooks/tasks/install-python.yaml
+++ b/playbooks/tasks/install-python.yaml
@@ -47,18 +47,10 @@
   become: true
   raw: ln -fs "/var/lib/toolbox/{{ ansible_ssh_user }}-python-3" /var/lib/toolbox/root-python-3
 
-- name: create /opt/bin
+- name: create binary directory
   become: true
-  raw: mkdir -p /opt/bin
+  raw: mkdir -p "{{ ansible_python_interpreter | dirname }}"
 
-- name: link binaries to toolbox
+- name: link python to toolbox
   become: true
-  raw: ln -fs /usr/bin/toolbox "/opt/bin/{{ item }}"
-  loop: &binaries
-  - python
-  - pip
-
-- name: set binary paths
-  set_fact:
-    "ansible_{{ item }}_interpreter": "/opt/bin/{{ item }}"
-  loop: *binaries
+  raw: ln -fs /usr/bin/toolbox "{{ ansible_python_interpreter }}"

--- a/playbooks/tasks/install-python.yaml
+++ b/playbooks/tasks/install-python.yaml
@@ -11,10 +11,10 @@
     # escaping or quoting the "limit string" in a heredoc disables parameter substitution
     # http://tldp.org/LDP/abs/html/here-docs.html#EX71C
     cmd: |
-      cat > ~/.toolboxrc << \EOF
+      cat > "/home/{{ ansible_ssh_user }}/.toolboxrc" << \EOF
       TOOLBOX_DOCKER_IMAGE=python
       TOOLBOX_DOCKER_TAG=3
-      TOOLBOX_BIND="$TOOLBOX_BIND --bind=/etc/passwd:/etc/passwd --bind=/home:/home"
+      TOOLBOX_BIND="$TOOLBOX_BIND --bind-ro=/etc/passwd:/etc/passwd --bind=/home:/home --bind=/root:/root"
       TOOLBOX_ENV=--chdir="/media/root/$PWD"
       TOOLBOX_USER="$USER"
 
@@ -31,10 +31,21 @@
       fi
       EOF
 
+# use the same toolbox configuration when run as root
+- name: link toolboxrc to root
+  become: true
+  raw: ln -fs "/home/{{ ansible_ssh_user }}/.toolboxrc" /root/.toolboxrc
+
 # the first run of toolbox will pull and unpack the docker image to the local filesystem
 # this can take a while so we'll pull it eagerly to avoid confusion or timeouts in subsequent steps
 - name: verify toolbox container image
   raw: toolbox echo hello world
+
+# toolbox unpacks the container filesystem to a directory containing the current user's name
+# since we want to reuse the same container for the root user we simply have to symlink it
+- name: link container filesystem to root
+  become: true
+  raw: ln -fs "/var/lib/toolbox/{{ ansible_ssh_user }}-python-3" /var/lib/toolbox/root-python-3
 
 - name: create /opt/bin
   become: true


### PR DESCRIPTION
This updated playbook leverages [CoreOS' Toolbox](https://github.com/coreos/toolbox) project built into every Container Linux installation to "install" Python. This has a few benefits over the docker run script we were running prior, mainly robustness and maintainability, but most importantly it also provides data persistence, allowing us to do things like `pip install` to enable other ansible modules.

This comes with some caveats, however, although no more than the last implentation:
- absolute paths on the host won't work as expected, the host filesystem is mounted at `/media/root`; use relative paths or paths that reference `$HOME` or `~`, both of which resolve correctly
- the unprivileged `core` user requires either `become` or `extra_args=--user` to install dependencies through pip