### PR TITLE
Certificates for authentication and secure communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+generated

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG ANSIBLE_VERSION=2.7
 
 RUN apk add --no-cache openssl && \
     apk add --no-cache --virtual=build-dependencies build-base libffi-dev openssl-dev && \
-    pip install ansible=="$ANSIBLE_VERSION" && \
+    pip install ansible=="$ANSIBLE_VERSION" pyopenssl && \
     apk del build-dependencies
 
 COPY . .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ x-common: &common
     # https://docs.python.org/3/using/cmdline.html#envvar-PYTHONWARNINGS
     PYTHONWARNINGS: ignore
   volumes:
-  - ./:/etc/corebernetes:ro
+  - ./:/etc/corebernetes
   - ~/.ssh:/root/.ssh:ro
 
 services:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,9 +1,0 @@
-# Corebernetes Architecture
-
-## Installation Tooling
-
-CoreOS is configured and installed with [Ansible](https://github.com/ansible/ansible), a configuration management tool. Ansible operates on an ["inventory"](/inventory/hosts.ini), with declarative configuration files [for each host](/inventory/host_vars/) or [logical groupings of hosts](/inventory/group_vars/) (for common config settings). [Configuration for ansible itself](/ansible.cfg) is also stored declaratively. Hosts are configured by ["playbooks"](/playbooks/), lists of idempotent tasks to apply to specified hosts or groups to achieve a desired state. Overall it looks like a fancy `make` over SSH.
-
-Ansible commands are run in containers to avoid additional configuration of the host machine. Unfortunately ansible does not publish official images, so we [build our own](/Dockerfile) from alpine. `ansible` and `ansible-playbook` can be [invoked through docker-compose](/docker-compose.yaml) (e.g., `docker-compose run ansible-playbook ...`).
-
-If you're familiar with compose you'll probably notice we're using it in a bit of a non-standard way. Compose is very good at two overlapping tasks: orchestrating local services, and declaratively storing runtime configuration. Since we only run short-lived, ad-hoc tasks and not long-running services we exclusively use the latter paradigm. Each "service" could be written as a `docker run` command, but they would be harder to maintain or extend.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,32 @@
+# Corebernetes Architecture & Design
+
+## Installation Tooling
+
+CoreOS is configured and installed with [Ansible](https://github.com/ansible/ansible), a configuration management tool. Ansible operates on an ["inventory"](/inventory/hosts.ini), with declarative configuration files [for each host](/inventory/host_vars/) or [logical groupings of hosts](/inventory/group_vars/) (for common config settings). [Configuration for ansible itself](/ansible.cfg) is also stored declaratively. Hosts are configured by ["playbooks"](/playbooks/), lists of idempotent tasks to apply to specified hosts or groups to achieve a desired state. Overall it looks like a fancy `make` over SSH.
+
+Ansible commands are run in containers to avoid additional configuration of the host machine. Unfortunately ansible does not publish official images, so we [build our own](/Dockerfile) from alpine. `ansible` and `ansible-playbook` can be [invoked through docker-compose](/docker-compose.yaml) (e.g., `docker-compose run ansible-playbook ...`).
+
+If you're familiar with compose you'll probably notice we're using it in a bit of a non-standard way. Compose is very good at two overlapping tasks: orchestrating local services, and declaratively storing runtime configuration. Since we only run short-lived, ad-hoc tasks and not long-running services we exclusively use the latter paradigm. Each "service" could be written as a `docker run` command, but they would be harder to maintain or extend.
+
+## Security
+
+All services within Corebernetes must operate securely. What this means differs for each service but in general we'll make heavy use of TLS, requiring it for communication (HTTPS) and authentication (mTLS) wherever possible.
+
+To minimize the damage an exposed private key can do we're leveraging multiple certificate authorities with segregated duties.
+
+* http: this authority is responsible for provisioning server certificates used to secure HTTP traffic between cluster services
+* etcd: this authority is responsible for provisioning client certficates to services that authenticate with etcd, including peer members
+**Kubernetes is still a work-in-progress with yet to be identified security considerations. As this project evolves the relevant certificate authorities be laid out here.**
+
+Private keys never leave the boxes they are generated on, instead the only files that change hands are the [certificate signing requests](https://www.sslshopper.com/what-is-a-csr-certificate-signing-request.html) and the certificates generated from them, both public data.
+
+| Ansible Host                                                                 	|      	| CoreOS Host                                         	|
+|------------------------------------------------------------------------------	|------	|-----------------------------------------------------	|
+| generates RSA key (`ca.key`)                                                 	|      	|                                                     	|
+| generates CSR (`ca.csr`) with constraint `CA:true`, signed by `ca.key`       	|      	|                                                     	|
+| re-signs `ca.csr` with `ca.key` to generate root certificate (`ca.crt`)      	| ---> 	| stores `ca.crt`                                     	|
+|                                                                              	|      	| generates RSA key (`coreos.key`)                    	|
+| stores `coreos.csr` in temporary directory                                   	| <--- 	| generates CSR (`coreos.csr`) signed by `coreos.key` 	|
+| signs `coreos.csr` with `ca.key` to generate leaf certificate (`coreos.crt`) 	| ---> 	| stores `coreos.crt`                                 	|
+
+The above example is orchestrated by [several ansible modules](/playbooks/tasks/x509/), see the task implementations for more details.

--- a/docs/design.md
+++ b/docs/design.md
@@ -20,13 +20,13 @@ To minimize the damage an exposed private key can do we're leveraging multiple c
 
 Private keys never leave the boxes they are generated on, instead the only files that change hands are the [certificate signing requests](https://www.sslshopper.com/what-is-a-csr-certificate-signing-request.html) and the certificates generated from them, both public data.
 
-| Ansible Host                                                                 	|      	| CoreOS Host                                         	|
-|------------------------------------------------------------------------------	|------	|-----------------------------------------------------	|
-| generates RSA key (`ca.key`)                                                 	|      	|                                                     	|
-| generates CSR (`ca.csr`) with constraint `CA:true`, signed by `ca.key`       	|      	|                                                     	|
-| re-signs `ca.csr` with `ca.key` to generate root certificate (`ca.crt`)      	| ---> 	| stores `ca.crt`                                     	|
-|                                                                              	|      	| generates RSA key (`coreos.key`)                    	|
-| stores `coreos.csr` in temporary directory                                   	| <--- 	| generates CSR (`coreos.csr`) signed by `coreos.key` 	|
-| signs `coreos.csr` with `ca.key` to generate leaf certificate (`coreos.crt`) 	| ---> 	| stores `coreos.crt`                                 	|
+| Ansible Host                                                                 |   | CoreOS Host                                         |
+|------------------------------------------------------------------------------|---|-----------------------------------------------------|
+| generates RSA key (`ca.key`)                                                 |   |                                                     |
+| generates CSR (`ca.csr`) with constraint `CA:true`, signed by `ca.key`       |   |                                                     |
+| re-signs `ca.csr` with `ca.key` to generate root certificate (`ca.crt`)      | → | stores `ca.crt`                                     |
+|                                                                              |   | generates RSA key (`coreos.key`)                    |
+| stores `coreos.csr` in temporary directory                                   | ← | generates CSR (`coreos.csr`) signed by `coreos.key` |
+| signs `coreos.csr` with `ca.key` to generate leaf certificate (`coreos.crt`) | → | stores `coreos.crt`                                 |
 
 The above example is orchestrated by [several ansible modules](/playbooks/tasks/x509/), see the task implementations for more details.

--- a/inventory/group_vars/corebernetes.yaml
+++ b/inventory/group_vars/corebernetes.yaml
@@ -1,2 +1,5 @@
 ansible_ssh_user: core
 ansible_python_interpreter: /opt/bin/python
+
+certificate_directory: embed/certs
+private_key_directory: embed/keys

--- a/inventory/host_vars/localhost.yaml
+++ b/inventory/host_vars/localhost.yaml
@@ -1,0 +1,3 @@
+# if using docker-compose recall that these are paths in the container, not the host
+certificate_directory: /etc/corebernetes/generated
+private_key_directory: /etc/corebernetes/generated

--- a/playbooks/certificates.yaml
+++ b/playbooks/certificates.yaml
@@ -8,7 +8,7 @@
     local_private_key_directory: "{{ hostvars['localhost']['private_key_directory'] }}"
   tasks:
   - name: provision http certificates
-    tags: ["http"]
+    tags: ["http", "https"]
     block:
     - set_fact:
         authority_cert: "{{ local_certificate_directory }}/http.crt"

--- a/playbooks/certificates.yaml
+++ b/playbooks/certificates.yaml
@@ -1,0 +1,33 @@
+# this playbook provisions certificates signed by existing authorities
+# tasks are grouped by certificate authorities and tagged for ease of use
+
+- hosts: corebernetes
+  gather_facts: false
+  vars:
+    local_certificate_directory: "{{ hostvars['localhost']['certificate_directory'] }}"
+    local_private_key_directory: "{{ hostvars['localhost']['private_key_directory'] }}"
+  tasks:
+  - name: provision http certificates
+    tags: ["http"]
+    block:
+    - set_fact:
+        authority_cert: "{{ local_certificate_directory }}/http.crt"
+        authority_key:  "{{ local_private_key_directory }}/http.key"
+
+    - include: tasks/x509/certificate.yaml
+      vars:
+        name: etcd-https
+        server: true
+
+  - name: provision etcd certificates
+    tags: ["etcd"]
+    block:
+    - set_fact:
+        authority_cert: "{{ local_certificate_directory }}/etcd.crt"
+        authority_key:  "{{ local_private_key_directory }}/etcd.key"
+
+    - include: tasks/x509/certificate.yaml
+      vars:
+        name: etcd-peer
+        client: true
+        server: true

--- a/playbooks/install.yaml
+++ b/playbooks/install.yaml
@@ -1,10 +1,25 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+  - include: tasks/x509/authority.yaml
+    loop:
+    - http
+    - etcd
+    loop_control:
+      loop_var: name
+
+- hosts: corebernetes
+  gather_facts: false
+  tasks:
+  - include: tasks/install-python.yaml
+
+- import_playbook: certificates.yaml
+
 - hosts: corebernetes
   gather_facts: false
   vars:
     ct_version: v0.9.0
   tasks:
-  - include_tasks: tasks/install-python.yaml
-
   - name: install ct
     get_url:
       url: "https://github.com/coreos/container-linux-config-transpiler/releases/download/{{ ct_version }}/ct-{{ ct_version }}-x86_64-unknown-linux-gnu"
@@ -15,10 +30,10 @@
     template:
       src: templates/containerlinux.yaml.j2
       dest: containerlinux.yaml
-      validate: ./ct -in-file %s # ensure our configuration is well-formed
+      validate: ./ct -in-file %s --files-dir "{{ certificate_directory }}" --files-dir "{{ private_key_directory }}" # ensure our configuration is well-formed
 
   - name: render ignition config
-    shell: ./ct -in-file containerlinux.yaml > ignition.json
+    shell: ./ct -in-file containerlinux.yaml --files-dir "{{ certificate_directory }}" --files-dir "{{ private_key_directory }}" > ignition.json
     # don't specify creates, otherwise ansible won't run this step at all if ignition.json exists
     # meaning ansible won't pick up changes to containerlinux.yaml
     # args:

--- a/playbooks/tasks/x509/authority.yaml
+++ b/playbooks/tasks/x509/authority.yaml
@@ -1,23 +1,8 @@
 # generates a self-signed certificate authority and its matching private key
 # run this on localhost
 
-- name: check required variables
-  assert:
-    that: purpose is defined
-
-- name: set default variables
-  set_fact:
-    certificate_directory: "{{ certificate_directory | default('/etc/ssl/certs') }}"
-    private_key_directory: "{{ private_key_directory | default('/etc/ssl/private') }}"
-
-- name: create output directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    mode: 0755
-  loop:
-  - "{{ certificate_directory }}"
-  - "{{ private_key_directory }}"
+- name: include boilerplate tasks
+  include: boilerplate.yaml
 
 - name: create signing key
   openssl_privatekey:
@@ -25,16 +10,18 @@
 
 - name: create self-signing request
   openssl_csr:
+    path: "{{ certificate_directory }}/{{ purpose }}.csr"
+    privatekey_path: "{{ private_key_directory }}/{{ purpose }}.key"
     organization_name: corebernetes
     common_name: "{{ purpose }}:authority"
     basic_constraints: CA:true
     basic_constraints_critical: true
-    path: "{{ certificate_directory }}/{{ purpose }}.csr"
-    privatekey_path: "{{ private_key_directory }}/{{ purpose }}.key"
+    key_usage: keyCertSign, cRLSign
+    key_usage_critical: true
 
 - name: self-sign certificate authority
   openssl_certificate:
-    provider: selfsigned
     path: "{{ certificate_directory }}/{{ purpose }}.crt"
     csr_path: "{{ certificate_directory }}/{{ purpose }}.csr"
     privatekey_path: "{{ private_key_directory }}/{{ purpose }}.key"
+    provider: selfsigned

--- a/playbooks/tasks/x509/authority.yaml
+++ b/playbooks/tasks/x509/authority.yaml
@@ -1,0 +1,40 @@
+# generates a self-signed certificate authority and its matching private key
+# run this on localhost
+
+- name: check required variables
+  assert:
+    that: purpose is defined
+
+- name: set default variables
+  set_fact:
+    certificate_directory: "{{ certificate_directory | default('/etc/ssl/certs') }}"
+    private_key_directory: "{{ private_key_directory | default('/etc/ssl/private') }}"
+
+- name: create output directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0755
+  loop:
+  - "{{ certificate_directory }}"
+  - "{{ private_key_directory }}"
+
+- name: create signing key
+  openssl_privatekey:
+    path: "{{ private_key_directory }}/{{ purpose }}.key"
+
+- name: create self-signing request
+  openssl_csr:
+    organization_name: corebernetes
+    common_name: "{{ purpose }}:authority"
+    basic_constraints: CA:true
+    basic_constraints_critical: true
+    path: "{{ certificate_directory }}/{{ purpose }}.csr"
+    privatekey_path: "{{ private_key_directory }}/{{ purpose }}.key"
+
+- name: self-sign certificate authority
+  openssl_certificate:
+    provider: selfsigned
+    path: "{{ certificate_directory }}/{{ purpose }}.crt"
+    csr_path: "{{ certificate_directory }}/{{ purpose }}.csr"
+    privatekey_path: "{{ private_key_directory }}/{{ purpose }}.key"

--- a/playbooks/tasks/x509/authority.yaml
+++ b/playbooks/tasks/x509/authority.yaml
@@ -6,14 +6,14 @@
 
 - name: create signing key
   openssl_privatekey:
-    path: "{{ private_key_directory }}/{{ purpose }}.key"
+    path: "{{ private_key_directory }}/{{ name }}.key"
 
 - name: create self-signing request
   openssl_csr:
-    path: "{{ certificate_directory }}/{{ purpose }}.csr"
-    privatekey_path: "{{ private_key_directory }}/{{ purpose }}.key"
+    path: "{{ certificate_directory }}/{{ name }}.csr"
+    privatekey_path: "{{ private_key_directory }}/{{ name }}.key"
     organization_name: corebernetes
-    common_name: "{{ purpose }}:authority"
+    common_name: "{{ name }}:authority"
     basic_constraints: CA:true
     basic_constraints_critical: true
     key_usage: keyCertSign, cRLSign
@@ -21,7 +21,7 @@
 
 - name: self-sign certificate authority
   openssl_certificate:
-    path: "{{ certificate_directory }}/{{ purpose }}.crt"
-    csr_path: "{{ certificate_directory }}/{{ purpose }}.csr"
-    privatekey_path: "{{ private_key_directory }}/{{ purpose }}.key"
+    path: "{{ certificate_directory }}/{{ name }}.crt"
+    csr_path: "{{ certificate_directory }}/{{ name }}.csr"
+    privatekey_path: "{{ private_key_directory }}/{{ name }}.key"
     provider: selfsigned

--- a/playbooks/tasks/x509/boilerplate.yaml
+++ b/playbooks/tasks/x509/boilerplate.yaml
@@ -1,0 +1,25 @@
+# pre-flight tasks common to other X509 modules that supplement, rather than contribute to, business logic
+
+- name: check required variables
+  assert:
+    that:
+    - purpose is defined
+
+- name: set default variables
+  set_fact:
+    certificate_directory: "{{ certificate_directory | default('/etc/ssl/certs') }}"
+    private_key_directory: "{{ private_key_directory | default('/etc/ssl/private') }}"
+
+- name: install python dependencies
+  pip:
+    name: pyopenssl
+    extra_args: --user
+
+- name: create output directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0755
+  loop:
+  - "{{ certificate_directory }}"
+  - "{{ private_key_directory }}"

--- a/playbooks/tasks/x509/boilerplate.yaml
+++ b/playbooks/tasks/x509/boilerplate.yaml
@@ -3,7 +3,7 @@
 - name: check required variables
   assert:
     that:
-    - purpose is defined
+    - name is defined
 
 - name: set default variables
   set_fact:

--- a/playbooks/tasks/x509/certificate.yaml
+++ b/playbooks/tasks/x509/certificate.yaml
@@ -21,12 +21,12 @@
 
 - name: create private key
   openssl_privatekey:
-    path: "{{ private_key_directory }}/{{ purpose }}.key"
+    path: "{{ private_key_directory }}/{{ name }}.key"
 
 - name: create signing request
   openssl_csr:
-    path: "{{ certificate_directory }}/{{ purpose }}.csr"
-    privatekey_path: "{{ private_key_directory }}/{{ purpose }}.key"
+    path: "{{ certificate_directory }}/{{ name }}.csr"
+    privatekey_path: "{{ private_key_directory }}/{{ name }}.key"
     subject: "{{ subject | default(omit) }}"
     basic_constraints: CA:false
     basic_constraints_critical: true
@@ -49,19 +49,19 @@
 
 - name: copy signing request from host
   fetch:
-    src: "{{ certificate_directory }}/{{ purpose }}.csr"
+    src: "{{ certificate_directory }}/{{ name }}.csr"
     dest: "{{ tempdir.path }}"
 
 - name: sign request
   local_action:
     module: openssl_certificate
-    path: "{{ tempdir.path }}/{{ inventory_hostname }}/{{ certificate_directory }}/{{ purpose }}.crt"
-    csr_path: "{{ tempdir.path }}/{{ inventory_hostname }}/{{ certificate_directory }}/{{ purpose }}.csr"
+    path: "{{ tempdir.path }}/{{ inventory_hostname }}/{{ certificate_directory }}/{{ name }}.crt"
+    csr_path: "{{ tempdir.path }}/{{ inventory_hostname }}/{{ certificate_directory }}/{{ name }}.csr"
     provider: ownca
     ownca_path: "{{ authority_cert | mandatory }}"
     ownca_privatekey_path: "{{ authority_key | mandatory }}"
 
 - name: copy certificate to host
   copy:
-    src: "{{ tempdir.path }}/{{ inventory_hostname }}/{{ certificate_directory }}/{{ purpose }}.crt"
-    dest: "{{ certificate_directory }}/{{ purpose }}.crt"
+    src: "{{ tempdir.path }}/{{ inventory_hostname }}/{{ certificate_directory }}/{{ name }}.crt"
+    dest: "{{ certificate_directory }}/{{ name }}.crt"

--- a/playbooks/tasks/x509/certificate.yaml
+++ b/playbooks/tasks/x509/certificate.yaml
@@ -2,31 +2,22 @@
 # no key material is exchanged between the two boxes, only a public CSR and public certificate
 # run this on a remote server
 
-- name: check required variables
-  assert:
-    that:
-    - purpose is defined
-    - authority_cert is defined
-    - authority_key is defined
+- name: include boilerplate tasks
+  include: boilerplate.yaml
 
-- name: set default variables
+- name: set usage defaults
   set_fact:
-    certificate_directory: "{{ certificate_directory | default('/etc/ssl/certs') }}"
-    private_key_directory: "{{ private_key_directory | default('/etc/ssl/private') }}"
+    client: "{{ client | default(False) }}"
+    server: "{{ server | default(subject is defined) }}"
 
-- name: install python dependencies
-  pip:
-    name: pyopenssl
-    extra_args: --user
-
-- name: create output directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    mode: 0755
-  loop:
-  - "{{ certificate_directory }}"
-  - "{{ private_key_directory }}"
+- name: set default server names
+  set_fact:
+    subject_alt_name:
+    - DNS:localhost
+    - DNS:{{ inventory_hostname }}
+    - IP:127.0.0.1
+    - IP:{{ ansible_host }}
+  when: server and subject_alt_name is not defined
 
 - name: create private key
   openssl_privatekey:
@@ -34,17 +25,20 @@
 
 - name: create signing request
   openssl_csr:
-    extended_key_usage:
-    - serverAuth
-    extended_key_usage_critical: true
-    subject_alt_name:
-    - DNS:localhost
-    - DNS:{{ inventory_hostname }}
-    - IP:127.0.0.1
-    - IP:{{ ansible_host }}
-    subject_alt_name_critical: true
     path: "{{ certificate_directory }}/{{ purpose }}.csr"
     privatekey_path: "{{ private_key_directory }}/{{ purpose }}.key"
+    subject: "{{ subject | default(omit) }}"
+    basic_constraints: CA:false
+    basic_constraints_critical: true
+    key_usage:
+    - digitalSignature
+    - nonRepudiation
+    - "{{ 'keyEncipherment' if server else omit }}"
+    key_usage_critical: true
+    extended_key_usage: "{{ [] + (['clientAuth'] if client else []) + (['serverAuth'] if server else []) }}"
+    extended_key_usage_critical: true
+    subject_alt_name: "{{ subject_alt_name | default(omit) }}"
+    subject_alt_name_critical: true
 
 - name: create local temporary directory for signing request
   run_once: true # reuse this directory throughout the play
@@ -61,11 +55,11 @@
 - name: sign request
   local_action:
     module: openssl_certificate
-    provider: ownca
     path: "{{ tempdir.path }}/{{ inventory_hostname }}/{{ certificate_directory }}/{{ purpose }}.crt"
     csr_path: "{{ tempdir.path }}/{{ inventory_hostname }}/{{ certificate_directory }}/{{ purpose }}.csr"
-    ownca_path: "{{ authority_cert }}"
-    ownca_privatekey_path: "{{ authority_key }}"
+    provider: ownca
+    ownca_path: "{{ authority_cert | mandatory }}"
+    ownca_privatekey_path: "{{ authority_key | mandatory }}"
 
 - name: copy certificate to host
   copy:

--- a/playbooks/tasks/x509/certificate.yaml
+++ b/playbooks/tasks/x509/certificate.yaml
@@ -7,8 +7,8 @@
 
 - name: set usage defaults
   set_fact:
-    client: "{{ client | default(False) }}"
-    server: "{{ server | default(subject is defined) }}"
+    client: "{{ client | default(subject is defined) }}"
+    server: "{{ server | default(False) }}"
 
 - name: set default server names
   set_fact:

--- a/playbooks/tasks/x509/server.yaml
+++ b/playbooks/tasks/x509/server.yaml
@@ -1,0 +1,68 @@
+# requests a server certificate from a signing authority and generates its matching private key
+# no key material is exchanged between the two boxes, only a public CSR and public certificate
+# run this on a remote server
+
+- name: check required variables
+  assert:
+    that:
+    - purpose is defined
+    - authority_cert is defined
+    - authority_key is defined
+
+- name: set default variables
+  set_fact:
+    certificate_directory: "{{ certificate_directory | default('/etc/ssl/certs') }}"
+    private_key_directory: "{{ private_key_directory | default('/etc/ssl/private') }}"
+
+- name: create output directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0755
+  loop:
+  - "{{ certificate_directory }}"
+  - "{{ private_key_directory }}"
+
+- name: create private key
+  openssl_privatekey:
+    path: "{{ private_key_directory }}/{{ purpose }}.key"
+
+- name: create signing request
+  openssl_csr:
+    extended_key_usage:
+    - serverAuth
+    extended_key_usage_critical: true
+    subject_alt_name:
+    - DNS:localhost
+    - DNS:{{ inventory_hostname }}
+    - IP:127.0.0.1
+    - IP:{{ ansible_host }}
+    subject_alt_name_critical: true
+    path: "{{ certificate_directory }}/{{ purpose }}.csr"
+    privatekey_path: "{{ private_key_directory }}/{{ purpose }}.key"
+
+- name: create local temporary directory for signing request
+  run_once: true # reuse this directory throughout the play
+  local_action:
+    module: tempfile
+    state: directory
+  register: tempdir
+
+- name: copy signing request from host
+  fetch:
+    src: "{{ certificate_directory }}/{{ purpose }}.csr"
+    dest: "{{ tempdir.path }}"
+
+- name: sign request
+  local_action:
+    module: openssl_certificate
+    provider: ownca
+    path: "{{ tempdir.path }}/{{ inventory_hostname }}/{{ certificate_directory }}/{{ purpose }}.crt"
+    csr_path: "{{ tempdir.path }}/{{ inventory_hostname }}/{{ certificate_directory }}/{{ purpose }}.csr"
+    ownca_path: "{{ authority_cert }}"
+    ownca_privatekey_path: "{{ authority_key }}"
+
+- name: copy certificate to host
+  copy:
+    src: "{{ tempdir.path }}/{{ inventory_hostname }}/{{ certificate_directory }}/{{ purpose }}.crt"
+    dest: "{{ certificate_directory }}/{{ purpose }}.crt"

--- a/playbooks/tasks/x509/server.yaml
+++ b/playbooks/tasks/x509/server.yaml
@@ -14,6 +14,11 @@
     certificate_directory: "{{ certificate_directory | default('/etc/ssl/certs') }}"
     private_key_directory: "{{ private_key_directory | default('/etc/ssl/private') }}"
 
+- name: install python dependencies
+  pip:
+    name: pyopenssl
+    extra_args: --user
+
 - name: create output directories
   file:
     path: "{{ item }}"


### PR DESCRIPTION
Adds modules for working with certificates, should be generic enough to support client or server certificates for all our cluster components. See [`playbooks/certificates.yaml`](playbooks/certificates.yaml) for example usage.